### PR TITLE
Added player death coordinates message upon death

### DIFF
--- a/src/main/java/com/artillexstudios/axgraves/grave/Grave.java
+++ b/src/main/java/com/artillexstudios/axgraves/grave/Grave.java
@@ -93,6 +93,15 @@ public class Grave {
             msg = msg.replace("%despawn-time%", StringUtils.formatTime(CONFIG.getInt("despawn-time-seconds", 180) * 1_000L - (System.currentTimeMillis() - spawned)));
             hologram.addLine(StringUtils.format(msg));
         }
+
+        if (CONFIG.getBoolean("global-announce-death-coordinates", true)){
+            for (Player p : Bukkit.getOnlinePlayers()){
+                p.sendMessage(String.format("%s died at X:%.2f Y:%.2f Z:%.2f", player.getName(), location.getX(), location.getY(), location.getZ())); 
+            }
+        } else if (CONFIG.getBoolean("private-announce-death-coordinates", true)){
+            player.sendMessage(String.format("You died at X:%.2f Y:%.2f Z:%.2f", location.getX(), location.getY(), location.getZ())); 
+        }
+
     }
 
     public void update() {

--- a/src/main/java/com/artillexstudios/axgraves/grave/Grave.java
+++ b/src/main/java/com/artillexstudios/axgraves/grave/Grave.java
@@ -108,7 +108,9 @@ public class Grave {
 
         if (CONFIG.getBoolean("private-announce-death-coordinates", false)){
             MESSAGEUTILS.sendFormatted(player, CONFIG.getString("prefix") + MESSAGES.getString("death-message-format.private"), deathMessageReplacements);
-        } else if (CONFIG.getBoolean("global-announce-death-coordinates", false)){
+        }
+
+        if (CONFIG.getBoolean("global-announce-death-coordinates", false)){
             Collection<? extends Player> deathMessageRecipients = Bukkit.getOnlinePlayers();
             int deathMessageRange = CONFIG.getInt("global-announce-death-message-range");
             if (deathMessageRange >= 0){

--- a/src/main/java/com/artillexstudios/axgraves/listeners/DeathListener.java
+++ b/src/main/java/com/artillexstudios/axgraves/listeners/DeathListener.java
@@ -52,14 +52,5 @@ public class DeathListener implements Listener {
 
         final GraveSpawnEvent graveSpawnEvent = new GraveSpawnEvent(player, grave);
         Bukkit.getPluginManager().callEvent(graveSpawnEvent);
-
-        Location deathLocation = player.getLocation();
-        if (CONFIG.getBoolean("global-announce-death-coordinates", true)){
-            for (Player p : Bukkit.getOnlinePlayers()){
-                p.sendMessage(String.format("%s died at X:%.2f Y:%.2f Z:%.2f", player.getName(), deathLocation.getX(), deathLocation.getY(), deathLocation.getZ())); 
-            }
-        } else if (CONFIG.getBoolean("private-announce-death-coordinates", true)){
-            player.sendMessage(String.format("You died at X:%.2f Y:%.2f Z:%.2f", deathLocation.getX(), deathLocation.getY(), deathLocation.getZ())); 
-        }
     }
 }

--- a/src/main/java/com/artillexstudios/axgraves/listeners/DeathListener.java
+++ b/src/main/java/com/artillexstudios/axgraves/listeners/DeathListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
 
 import static com.artillexstudios.axgraves.AxGraves.CONFIG;
@@ -51,5 +52,14 @@ public class DeathListener implements Listener {
 
         final GraveSpawnEvent graveSpawnEvent = new GraveSpawnEvent(player, grave);
         Bukkit.getPluginManager().callEvent(graveSpawnEvent);
+
+        Location deathLocation = player.getLocation();
+        if (CONFIG.getBoolean("global-announce-death-coordinates", true)){
+            for (Player p : Bukkit.getOnlinePlayers()){
+                p.sendMessage(String.format("%s died at X:%.2f Y:%.2f Z:%.2f", player.getName(), deathLocation.getX(), deathLocation.getY(), deathLocation.getZ())); 
+            }
+        } else if (CONFIG.getBoolean("private-announce-death-coordinates", true)){
+            player.sendMessage(String.format("You died at X:%.2f Y:%.2f Z:%.2f", deathLocation.getX(), deathLocation.getY(), deathLocation.getZ())); 
+        }
     }
 }

--- a/src/main/java/com/artillexstudios/axgraves/listeners/DeathListener.java
+++ b/src/main/java/com/artillexstudios/axgraves/listeners/DeathListener.java
@@ -12,7 +12,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
 
 import static com.artillexstudios.axgraves.AxGraves.CONFIG;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,6 +19,12 @@ instant-pickup-only-own: false
 # i would only recommend disabling this if you have a permission based keepinventory system
 override-keep-inventory: true
 
+# should the coordinates of the grave be announced to all players ?
+global-announce-death-coordinates: false
+
+# should the coordinates of the grave be announced to the player who died ?
+private-announce-death-coordinates: true
+
 # how high should death chest holograms spawn?
 # only applies to new graves
 hologram-height: 0.75

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,11 +19,17 @@ instant-pickup-only-own: false
 # i would only recommend disabling this if you have a permission based keepinventory system
 override-keep-inventory: true
 
-# should the coordinates of the grave be announced to all players ?
-global-announce-death-coordinates: false
+# should the coordinates of the grave only be announced to the player who died ?
+private-announce-death-coordinates: false 
 
-# should the coordinates of the grave be announced to the player who died ?
-private-announce-death-coordinates: true
+# should the coordinates of the grave be announced to all players ?
+global-announce-death-coordinates: false 
+
+# the range in which to notify players of a death.
+# -1 for everyone in all words
+# 0 for everyone in the same world
+# >0 for a range in the same world
+global-announce-death-message-range: -1
 
 # how high should death chest holograms spawn?
 # only applies to new graves
@@ -60,4 +66,4 @@ blacklisted-items:
     name-contains: "Banned item's name"
 
 # do not edit
-version: 5
+version: 6

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -18,5 +18,9 @@ reload:
 interact:
   not-your-grave: "&#FF3333You can only open your own grave!"
 
+death-message-format:
+  private: "You died at X:%X% Y:%Y% Z:%Z% in %world%!"
+  global: "%player% died at X:%X% Y:%Y% Z:%Z% in %world%!"
+
 # do not edit
-version: 2
+version: 3


### PR DESCRIPTION
Added a message in chat when a player dies.
Fixes #2 
It can be configured to be a message to every player, only the player who died or to not message anyone.