### PR TITLE
Add optional death broadcast message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.artillexstudios</groupId>
     <artifactId>AxGraves</artifactId>
-    <version>1.29.0</version>
+    <version>1.30.0</version>
     <packaging>jar</packaging>
 
     <name>AxGraves</name>

--- a/src/main/java/com/artillexstudios/axgraves/grave/Grave.java
+++ b/src/main/java/com/artillexstudios/axgraves/grave/Grave.java
@@ -89,6 +89,18 @@ public class Grave {
                 MESSAGEUTILS.sendLang(pl, "death-message.message", Map.of("%world%", LocationUtils.getWorldName(location.getWorld()), "%x%", "" + location.getBlockX(), "%y%", "" + location.getBlockY(), "%z%", "" + location.getBlockZ()));
             }
         }
+
+        if (LANG.getBoolean("death-broadcast.enabled", false)) {
+            Map<String, String> placeholders = Map.of(
+                    "%player%", playerName,
+                    "%world%", LocationUtils.getWorldName(location.getWorld()),
+                    "%x%", "" + location.getBlockX(),
+                    "%y%", "" + location.getBlockY(),
+                    "%z%", "" + location.getBlockZ());
+            for (Player online : Bukkit.getOnlinePlayers()) {
+                MESSAGEUTILS.sendLang(online, "death-broadcast.message", placeholders);
+            }
+        }
         items.forEach(gui::addItem);
 
         this.entity = NMSHandlers.getNmsHandler().createEntity(EntityType.ARMOR_STAND, location.clone().add(0, 1 + CONFIG.getFloat("head-height", -1.2f), 0));

--- a/src/main/java/com/artillexstudios/axgraves/listeners/DeathListener.java
+++ b/src/main/java/com/artillexstudios/axgraves/listeners/DeathListener.java
@@ -19,11 +19,14 @@ import org.bukkit.plugin.EventExecutor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import static com.artillexstudios.axgraves.AxGraves.CONFIG;
 
 public class DeathListener implements Listener {
     private static List<String> disabledWorlds;
+    private static List<Pattern> disabledWorldPatterns;
     private static List<String> blacklistedDeathCauses;
     private static boolean overrideKeepInventory;
     private static boolean overrideKeepLevel;
@@ -32,13 +35,43 @@ public class DeathListener implements Listener {
     private static float xpKeepPercentage;
 
     public static void reload() {
-        disabledWorlds = CONFIG.getStringList("disabled-worlds");
+        List<String> rawDisabledWorlds = CONFIG.getStringList("disabled-worlds");
+        disabledWorlds = new ArrayList<>();
+        disabledWorldPatterns = new ArrayList<>();
+        for (String entry : rawDisabledWorlds) {
+            if (entry.startsWith("regex:")) {
+                String pattern = entry.substring("regex:".length());
+                if (pattern.isEmpty()) {
+                    LogUtils.error("invalid regex in disabled-worlds: '{}' is empty", entry);
+                    continue;
+                }
+                try {
+                    disabledWorldPatterns.add(Pattern.compile(pattern));
+                } catch (PatternSyntaxException ex) {
+                    LogUtils.error("invalid regex in disabled-worlds: '{}' ({})", entry, ex.getMessage());
+                }
+            } else {
+                disabledWorlds.add(entry);
+            }
+        }
         blacklistedDeathCauses = CONFIG.getStringList("blacklisted-death-causes");
         overrideKeepInventory = CONFIG.getBoolean("override-keep-inventory", true);
         overrideKeepLevel = CONFIG.getBoolean("override-keep-level", true);
         storeItems = CONFIG.getBoolean("store-items", true);
         storeXP = CONFIG.getBoolean("store-xp", true);
         xpKeepPercentage = CONFIG.getFloat("xp-keep-percentage", 1f);
+    }
+
+    private static boolean isWorldDisabled(String worldName) {
+        if (disabledWorlds.contains(worldName)) {
+            return true;
+        }
+        for (Pattern pattern : disabledWorldPatterns) {
+            if (pattern.matcher(worldName).matches()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public DeathListener() {
@@ -74,7 +107,7 @@ public class DeathListener implements Listener {
         Player player = event.getEntity();
 
         if (debug) LogUtils.debug("[{}] spawning grave", player.getName());
-        if (disabledWorlds.contains(player.getWorld().getName())) {
+        if (isWorldDisabled(player.getWorld().getName())) {
             if (debug) LogUtils.debug("[{}] return: disabled world {}", player.getName(), player.getWorld().getName());
             return;
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -124,9 +124,12 @@ world-name:
   world_the_end: "The End"
 
 # worlds where graves won't spawn
-# this is case-sensitive
+# entries are case-sensitive exact matches by default
+# prefix an entry with "regex:" to match by pattern, e.g. "regex:world_.*" matches any world starting with "world_"
+# invalid regex entries are skipped and logged
 disabled-worlds:
   - "blacklisted_world"
+  - "regex:blacklisted_worlds_.*"
 
 # if players die from any of the following, no graves will be spawned
 # list of valid values: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -27,6 +27,10 @@ death-message:
   enabled: false
   message: "&#FFAAAAYou have died at &f%world% %x%, %y%, %z%&#FFAAAA!"
 
+death-broadcast:
+  enabled: false
+  message: "&#FFAAAA%player% has died at &f%world% %x%, %y%, %z%&#FFAAAA!"
+
 grave-list:
   header: "&#FF00FF&l=== GRAVES ==="
   grave: "&#FF00FF[TP] &#FFAAFF%player% &7- &#FFAAFF%world% %x%, %y%, %z% &7(%time%)"


### PR DESCRIPTION
## Summary
Adds an optional server-wide broadcast that announces when a player dies and where their grave
spawned. This is separate from the existing `death-message` (which only messages the deceased
player), so both can be toggled independently.

This PR has been started from: https://github.com/Artillex-Studios/AxGraves/pull/82
When #82 is merged first it will only display the correct changes.

## Motivation
`death-message` only notifies the player who died. Some servers want the whole server to see death
announcements (e.g. for PvP servers, small communities, or to let others rush the grave). There was
no built-in way to broadcast grave coordinates to all online players.

## How it works
- When `death-broadcast.enabled` is `true`, the configured message is sent to **all online players**
  the moment a grave spawns.
- **Disabled by default**, no behavior change for existing setups.
- Fully independent from `death-message`; either, both, or neither can be enabled.

### New config (`messages.yml`)
```yml
death-broadcast:
  enabled: false
  message: "&#FFAAAA%player% has died at &f%world% %x%, %y%, %z%&#FFAAAA!"
```